### PR TITLE
Updated release workflows and changelog config.

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -3,13 +3,6 @@ name: Release Prepare
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - 'CHANGELOG.*'
-      - 'changelogs/**'
-      - 'galaxy.yml'
 
 jobs:
   prepare_release:
@@ -57,7 +50,7 @@ jobs:
 
       - name: Echo calculated version
         run: |
-          echo "version: ${{ steps.version.outputs.new_tag }}"
+          echo "New version is: ${{ steps.version.outputs.new_tag }}"
 
       - name: Update galaxy.yml version
         run: |
@@ -66,7 +59,7 @@ jobs:
 
       - name: Generate changelog
         run: |
-          antsibull-changelog generate
+          antsibull-changelog release
 
       - name: Commit updated files and open pull request
         uses: peter-evans/create-pull-request@v7
@@ -76,13 +69,14 @@ jobs:
             galaxy.yml
             CHANGELOG.*
             changelogs/changelog.yaml
+            changelogs/fragments/**
           commit-message: "Prepare release ${{ steps.version.outputs.new_tag }}"
-          branch: release-draft
+          branch: release/${{ steps.version.outputs.new_tag }}
           title: "Release ${{ steps.version.outputs.new_tag }}"
           body: |
             This PR prepares version `${{ steps.version.outputs.new_tag }}`.
             - Updated version in `galaxy.yml`
-            - Generated changelog preview (fragments not yet archived)
+            - Generated release changelog
             - Draft release created
 
       - name: Delete old drafts
@@ -97,4 +91,4 @@ jobs:
           draft: true
           name: ${{ steps.version.outputs.new_tag }}
           tag_name: ${{ steps.version.outputs.new_tag }}
-          target_commitish: release-draft
+          target_commitish: release/${{ steps.version.outputs.new_tag }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -35,26 +35,6 @@ jobs:
         run: |
           antsibull-changelog release
 
-      - name: Create PR for archived fragments and changelog
-        id: create_pr
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ github.token }}
-          branch: release-fragments/${{ github.event.release.tag_name }}
-          title: "Archive changelog fragments for release ${{ github.event.release.tag_name }}"
-          body: |
-            This PR archives the changelog fragments used in release ${{ github.event.release.tag_name }}
-            and updates all changelog files.
-          add-paths: |
-            CHANGELOG.*
-            changelogs/changelog.yaml
-            changelogs/fragments/*
-
-      - name: Enable Pull Request Automerge
-        run: gh pr merge ${{ steps.create_pr.outputs.pull-request-number }} --merge --auto
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
       - name: Build collection
         run: ansible-galaxy collection build
 

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -1,5 +1,6 @@
 ---
 add_plugin_period: true
+archive_path_template: changelogs/fragments/archive/{version}
 changelog_nice_yaml: true
 changelog_sort: version
 changes_file: changelog.yaml


### PR DESCRIPTION
Moving to run the release-prepare workflow manually only, and then the release-publish workflow will run automatically after a draft release has been (manually) converted to a stable release. Also enabled fragment archives for historical purposes.